### PR TITLE
Use `scrollIntoViewIfNeeded `

### DIFF
--- a/src/pages/content/reducer/find-next.ts
+++ b/src/pages/content/reducer/find-next.ts
@@ -29,11 +29,7 @@ const reducer: Reducer = (state) => {
     binarySearchIndex(nextState.found, nextState.highlightId, (match) => match.id)
   ]?.ranges.forEach((range, index) => {
     if (index === 0) {
-      range.startContainer.parentElement?.scrollIntoView({
-        behavior: "instant",
-        block: "center",
-        inline: "center",
-      });
+      range.startContainer.parentElement?.scrollIntoViewIfNeeded(true);
     }
     highlights({ range, isAdd: true, isThis: true });
     highlights({ range, isAdd: false, isThis: false });

--- a/src/pages/content/reducer/find-next.ts
+++ b/src/pages/content/reducer/find-next.ts
@@ -31,8 +31,8 @@ const reducer: Reducer = (state) => {
     if (index === 0) {
       range.startContainer.parentElement?.scrollIntoView({
         behavior: "instant",
-        block: "nearest",
-        inline: "nearest",
+        block: "center",
+        inline: "center",
       });
     }
     highlights({ range, isAdd: true, isThis: true });


### PR DESCRIPTION
This is just a proposal to make scroll behavior similar to native Chrome's.
[The method](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded) does not work in Firefox, but since this is a Chrome extension, I believe it is not a problem?